### PR TITLE
fix/erc777-withdrawal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+### Changed
+ - Removed ```isERC777``` functionality.
+
 ## [2.1.0] - 2018-04-26
  
 ### Changed

--- a/contracts/Vault/Vault.sol
+++ b/contracts/Vault/Vault.sol
@@ -13,8 +13,6 @@ contract Vault is Ownable, VaultInterface {
 
     address constant public ETH = 0x0;
 
-    mapping (address => bool) public isERC777;
-
     // user => spender => approved
     mapping (address => mapping (address => bool)) private approved;
     mapping (address => mapping (address => uint)) private balances;
@@ -135,23 +133,7 @@ contract Vault is Ownable, VaultInterface {
     }
 
     function tokensReceived(address, address from, address, uint amount, bytes, bytes) public {
-        if (!isERC777[msg.sender]) {
-            isERC777[msg.sender] = true;
-        }
-
         depositFor(from, msg.sender, amount);
-    }
-
-    /// @dev Marks a token as an ERC777 token.
-    /// @param token Address of the token.
-    function setERC777(address token) public onlyOwner {
-        isERC777[token] = true;
-    }
-
-    /// @dev Unmarks a token as an ERC777 token.
-    /// @param token Address of the token.
-    function unsetERC777(address token) public onlyOwner {
-        isERC777[token] = false;
     }
 
     /// @dev Allows owner to withdraw tokens accidentally sent to the contract.
@@ -196,11 +178,6 @@ contract Vault is Ownable, VaultInterface {
     function withdrawTo(address user, address token, uint amount) private {
         if (token == ETH) {
             user.transfer(amount);
-            return;
-        }
-
-        if (isERC777[token]) {
-            ERC777(token).send(user, amount);
             return;
         }
 

--- a/test/TestVault.js
+++ b/test/TestVault.js
@@ -100,14 +100,6 @@ contract('Vault', function (accounts) {
         });
     });
 
-    it('should allow setting and unsetting of ERC777 token', async () => {
-        await vault.setERC777(token.address, {from: accounts[0]});
-        assert.equal(await vault.isERC777(token.address), true);
-
-        await vault.unsetERC777(token.address, {from: accounts[0]});
-        assert.equal(await vault.isERC777(token.address), false);
-    });
-
     it('should allow a maker to approve and unapprove an exchange', async () => {
         await vault.addSpender(accounts[1]);
 


### PR DESCRIPTION
Removes special `isERC777` function. This saves gas, and additionally blocks from marking a non ERC777 token as ERC777 which would prevent defaults.